### PR TITLE
Update Giganews Link to refer to the current special

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,7 @@
 {% include header.html %}
     {{ content }}
     <aside>
-        <a href="http://www.giganews.com/?a=SABnzbd:landing" target="_blank">
+        <a href="https://www.giganews.com/usenet-special/?a=SABnzbd:corner" target="_blank">
             <img alt="Usenet" src="/images/gn_tng_180x180_tri.gif" width="180" height="180" />
         </a>
     </aside>


### PR DESCRIPTION
Our contact from Giganews has suggested that we update the banner link to point to a specific landing page relevant to our corner ad. This PR updates that link.