### PR TITLE
updates for the NAS package download page

### DIFF
--- a/.directory
+++ b/.directory
@@ -1,4 +1,0 @@
-[Dolphin]
-Timestamp=2017,10,2,16,1,35
-Version=3
-ViewMode=1

--- a/.directory
+++ b/.directory
@@ -1,0 +1,4 @@
+[Dolphin]
+Timestamp=2017,10,2,16,1,35
+Version=3
+ViewMode=1

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 _site/
 .sass-cache/
 .jekyll-metadata
+.directory
 
 # =========================
 # Operating System Files

--- a/wiki/installation/install-nas.md
+++ b/wiki/installation/install-nas.md
@@ -2,15 +2,14 @@
 title: Install SABnzbd on a NAS
 ---
 
-Packages are maintained by the community.
+Packages maintained by the community.
 
 ## Synology
 
-* [Synology packe from SynoCommunity](http://www.synocommunity.com/packages)
+* [Synology package from SynoCommunity](http://www.synocommunity.com/packages)
 
 ## QNAP
 
-* [QNAP package by Clinton Hall](http://bit.ly/2jPntF9) (latest versions and support can be found [here](http://forum.qnap.com/viewtopic.php?f=133&t=86644))
-* [QNAP installer script](https://forum.qnap.com/viewtopic.php?f=320&t=132373)
+* [Sherpa installer script](https://forum.qnap.com/viewtopic.php?f=320&t=132373)
 
 Did we miss any? [Let us know](https://github.com/sabnzbd/sabnzbd.github.io/issues/new?title=Improve%3A+Install+SABnzbd+on+a+NAS&body=%23%23+URL%3A+%2Fwiki%2Finstallation%2Finstall-nas.html%0A%0AImprovement:%0A)


### PR DESCRIPTION
This is primarily to remove the reference to Clinton Hall's old SABnzbd QPKG. It seems he's no longer developing this and hasn't been active on the QNAP forum for some time. 

His package is now non-functional due to changes in the QNAP OS and should not be installed. 
