### PR TITLE
Update CentOS 7 instructions

### DIFF
--- a/wiki/extra/python3.md
+++ b/wiki/extra/python3.md
@@ -79,8 +79,7 @@ dnf install par2cmdline
 ```
 #### Centos 7
 ```
-yum -y install https://centos7.iuscommunity.org/ius-release.rpm
-yum -y install git python36 python36-pip
+yum -y install git python3-pip
 python3 -m pip install --upgrade pip
 git clone https://github.com/sabnzbd/sabnzbd.git
 cd sabnzbd/


### PR DESCRIPTION
With the release of CentOS 7.1908, python3 is now in the main repos. Adding IUS is no longer necessary. Also, python3-pip pulls in python3 as a dependency, you don't have to specify them both.

resolves #80