### PR TITLE
Update Debian installation docs for Trixie

### DIFF
--- a/wiki/installation/install-debian.md
+++ b/wiki/installation/install-debian.md
@@ -10,33 +10,33 @@ If your base distribution is Debian we _strongly_ recommend using some kind of c
 
 ## Installing from Debian Backports
 
-If you _must_ install from APT we recommend you use [Debian Backports](https://backports.debian.org/) to ensure you receive an actually up-to-date version of SABnzbd. These specific instructions are based on the current stable version of Debian 'Bookworm', but the instructions should hold true for future releases as well, just swap out all references to `bookworm` to `trixie` or whatever future Debian release you are running.
+If you _must_ install from APT we recommend you use [Debian Backports](https://backports.debian.org/) to ensure you receive an actually up-to-date version of SABnzbd. These specific instructions are based on the current stable version of Debian 13 'Trixie', but the instructions should hold true for most versions of Debian, including future releases. Just _literally_ swap out all the references below from `trixie` to `forky` or whatever Debian release you're running.
 
 - Edit `/etc/apt/sources.list` with sudo / as root
 - Confirm that your existing sources include Debian's `main`, `contrib`, and `non-free` repos. Your configuration should look something like this:
 
     ```
-    deb http://deb.debian.org/debian/ bookworm main contrib non-free
-    deb-src http://deb.debian.org/debian/ bookworm main contrib non-free
+    deb http://deb.debian.org/debian/ trixie main contrib non-free
+    deb-src http://deb.debian.org/debian/ trixie main contrib non-free
 
-    deb http://security.debian.org/debian-security bookworm-security main contrib non-free
-    deb-src http://security.debian.org/debian-security bookworm-security main contrib non-free
+    deb http://security.debian.org/debian-security trixie-security main contrib non-free
+    deb-src http://security.debian.org/debian-security trixie-security main contrib non-free
 
-    deb http://deb.debian.org/debian/ bookworm-updates main contrib non-free
-    deb-src http://deb.debian.org/debian/ bookworm-updates main contrib non-free
+    deb http://deb.debian.org/debian/ trixie-updates main contrib non-free
+    deb-src http://deb.debian.org/debian/ trixie-updates main contrib non-free
     ```
 
 - NOTE: You may have _other_ repos like `non-free-firmware`, that's OK please keep any extra lines, just make sure you at least have `main`, `contrib`, and `non-free` and add whichever of them you don't already have to each line.
-- Add the `bookworm-backports` repo at the bottom:
+- Add the `trixie-backports` repo at the bottom:
 
     ```
-    deb http://deb.debian.org/debian bookworm-backports main contrib non-free
+    deb http://deb.debian.org/debian trixie-backports main contrib non-free
     ```
 
 - Save the file
 - Update apt: `sudo apt update`
 	- It should show you downloading any contrib / non-free repo metadata you didn't previously have
-- Install SABnzbd from backports: `sudo apt install -t bookworm-backports sabnzbdplus`
+- Install SABnzbd from backports: `sudo apt install -t trixie-backports sabnzbdplus`
 	- NOTE: This will JUST install the packages from backports if it provides specific versions we request (like `python3-sabctools`), but will prefer your stable packages if possible (like `unrar`)
 - That's it, you've installed SABnzbd from Debian Backports.
 


### PR DESCRIPTION
A user on Discord got tripped up by the docs saying "bookworm is latest release, here are docs that say bookworm", so I updated the docs for Trixie and reworded the bit about how to make it work for any Debian version.